### PR TITLE
Fixing an issue with pagination links wrapping images.

### DIFF
--- a/jquery.paging.js
+++ b/jquery.paging.js
@@ -3,6 +3,7 @@
  * http://www.xarg.org/project/jquery-color-plugin-xcolor/
  *
  * Copyright (c) 2011, Robert Eisele (robert@xarg.org)
+ *               2011, Daniel Poulin (crimsonmage@gmail.com)
  * Dual licensed under the MIT or GPL Version 2 licenses.
  **/
 
@@ -461,6 +462,8 @@
 			ev["preventDefault"]();
 
 			var obj = ev["target"];
+
+			if (obj.nodeName.toLowerCase() === 'img') obj = $(ev.target).parent()[0];
 
 			Paging["setPage"]($.data(obj, "page"));
 


### PR DESCRIPTION
When for example the next button is wrapped around an image, event
['target'] reports the image element, so we must check for this
and have the plugin go to it's parent, the anchor.
