### PR TITLE
Fix for canceling refresh by calling Paging.setOptions() to clear out refresh.url during onRefresh().

### DIFF
--- a/jquery.paging.js
+++ b/jquery.paging.js
@@ -217,11 +217,14 @@
 						$["ajax"]({
 							"url": o.opts["refresh"]["url"],
 							"success": function(data) {
-
-								try {
-									var tmp = $["parseJSON"](data);
-								} catch (o) {
-									return;
+								if (typeof(data) == "object") {
+									var tmp = data;
+								} else {
+									try {
+										var tmp = $["parseJSON"](data);
+									} catch (o) {
+										return;
+									}
 								}
 								o.opts["onRefresh"](tmp);
 							}


### PR DESCRIPTION
Left a comment at http://www.xarg.org/2011/09/jquery-pagination-revised/ about this fix. 

The issue is that when a user calls Paging.setOptions() to clear out refresh.url, ajax requests continue with a malformed url. The fix is to cancel the interval before evaluating the url.
